### PR TITLE
Bugfixes | E-Mail Adressen kopieren | Gruppenlisten Beschreibung

### DIFF
--- a/LagerInsights/IO/DeserializeXML.cs
+++ b/LagerInsights/IO/DeserializeXML.cs
@@ -21,7 +21,6 @@ public class DeserializeXML<T> where T : class
         catch (Exception ex)
         {
             LOGGING.Write(ex.Message, MethodBase.GetCurrentMethod().Name, EventLogEntryType.Error);
-
             return default;
         }
     }

--- a/LagerInsights/LagerInsights.csproj
+++ b/LagerInsights/LagerInsights.csproj
@@ -11,8 +11,8 @@
 		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
 		<NeutralLanguage>de-DE</NeutralLanguage>
 		<StartupObject>LagerInsights.App</StartupObject>
-		<AssemblyVersion>1.0.13</AssemblyVersion>
-		<FileVersion>1.0.13</FileVersion>
+		<AssemblyVersion>1.0.14</AssemblyVersion>
+		<FileVersion>1.0.14</FileVersion>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -84,7 +84,7 @@
 		<NugetTools>$(PkgNuGet_CommandLine)\tools</NugetTools>
 		<SquirrelTools>$(Pkgsquirrel_windows)\tools</SquirrelTools>
 
-		<Version>1.0.13</Version>
+		<Version>1.0.14</Version>
 
 		<NuspecFile>$(ProjectDir)ReleaseSpec.nuspec</NuspecFile>
 	</PropertyGroup>

--- a/LagerInsights/LagerInsights.csproj
+++ b/LagerInsights/LagerInsights.csproj
@@ -11,8 +11,8 @@
 		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
 		<NeutralLanguage>de-DE</NeutralLanguage>
 		<StartupObject>LagerInsights.App</StartupObject>
-		<AssemblyVersion>1.0.14</AssemblyVersion>
-		<FileVersion>1.0.14</FileVersion>
+		<AssemblyVersion>1.0.15</AssemblyVersion>
+		<FileVersion>1.0.15</FileVersion>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -84,7 +84,7 @@
 		<NugetTools>$(PkgNuGet_CommandLine)\tools</NugetTools>
 		<SquirrelTools>$(Pkgsquirrel_windows)\tools</SquirrelTools>
 
-		<Version>1.0.14</Version>
+		<Version>1.0.15</Version>
 
 		<NuspecFile>$(ProjectDir)ReleaseSpec.nuspec</NuspecFile>
 	</PropertyGroup>

--- a/LagerInsights/Models/Jugendfeuerwehr.cs
+++ b/LagerInsights/Models/Jugendfeuerwehr.cs
@@ -26,7 +26,10 @@ public class Jugendfeuerwehr : INotifyPropertyChanged
 
     public DateTime? TimeStampAnmeldung { get; set; }
     public DateTime? TimeStampAenderung { get; set; }
+
     private decimal? gezahlterBeitrag;
+
+    [XmlIgnore]
     public decimal? GezahlterBeitrag
     {
         get => gezahlterBeitrag;
@@ -40,11 +43,60 @@ public class Jugendfeuerwehr : INotifyPropertyChanged
             }
         }
     }
+    [XmlElement("GezahlterBeitrag")]
+    public string GezahlterBeitragRaw
+    {
+        get => GezahlterBeitrag?.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        set
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                GezahlterBeitrag = null;
+            else if (decimal.TryParse(value, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var result))
+                GezahlterBeitrag = result;
+            else
+                GezahlterBeitrag = null;
+        }
+    }
+
+    [XmlIgnore]
     public DateTime? TimeStampGezahlterBeitrag { get; set; } //Änderungszeitpunkt des gezahlten Beitrages zum Abgleich mit den Versionen
+
+    [XmlElement("TimeStampGezahlterBeitrag")]
+    public string TimeStampGezahlterBeitragRaw
+    {
+        get => TimeStampGezahlterBeitrag?.ToString("o");
+        set
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                TimeStampGezahlterBeitrag = null;
+            else if (DateTime.TryParse(value, null, System.Globalization.DateTimeStyles.RoundtripKind, out var result))
+                TimeStampGezahlterBeitrag = result;
+            else
+                TimeStampGezahlterBeitrag = null;
+        }
+    }
+
 
 
     private bool? einverstaendniserklaerung;
 
+
+    [XmlElement("Einverstaendniserklaerung")]
+    public string EinverstaendniserklaerungRaw
+    {
+        get => Einverstaendniserklaerung?.ToString().ToLower();
+        set
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                Einverstaendniserklaerung = null;
+            else if (bool.TryParse(value, out var result))
+                Einverstaendniserklaerung = result;
+            else
+                Einverstaendniserklaerung = null;
+        }
+    }
+
+    [XmlIgnore]
     public bool? Einverstaendniserklaerung
     {
         get => einverstaendniserklaerung;
@@ -58,7 +110,27 @@ public class Jugendfeuerwehr : INotifyPropertyChanged
             }
         }
     }
+
+
+    [XmlIgnore]
     public DateTime? TimeStampEinverstaendniserklaerung { get; set; } //Änderungszeitpunkt der Einverständniserklärung zum Abgleich mit den Versionen
+
+    [XmlElement("TimeStampEinverstaendniserklaerung")]
+    public string TimeStampEinverstaendniserklaerungRaw
+    {
+        get => TimeStampEinverstaendniserklaerung?.ToString("o");
+        set
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                TimeStampEinverstaendniserklaerung = null;
+            else if (DateTime.TryParse(value, null, System.Globalization.DateTimeStyles.RoundtripKind, out var result))
+                TimeStampEinverstaendniserklaerung = result;
+            else
+                TimeStampEinverstaendniserklaerung = null;
+        }
+    }
+
+
 
     private string? zeltdorf;
 
@@ -75,9 +147,10 @@ public class Jugendfeuerwehr : INotifyPropertyChanged
             }
         }
     }
-
+    [XmlIgnore]
     public DateTime? TimeStampZeltdorf { get; set; } //Änderungszeitpunkt des Zeltdorfes zum Abgleich mit den Versionen
 
+    [XmlIgnore]
     public decimal? Teilnehmerbeitrag
     {
         get => teilnehmerbeitrag;
@@ -90,7 +163,35 @@ public class Jugendfeuerwehr : INotifyPropertyChanged
             }
         }
     }
+    [XmlElement("Teilnehmerbeitrag")]
+    public string TeilnehmerbeitragRaw
+    {
+        get => Teilnehmerbeitrag?.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        set
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                Teilnehmerbeitrag = null;
+            else if (decimal.TryParse(value, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var result))
+                Teilnehmerbeitrag = result;
+            else
+                Teilnehmerbeitrag = null;
+        }
+    }
 
+    [XmlElement("TimeStampZeltdorf")]
+    public string TimeStampZeltdorfRaw
+    {
+        get => TimeStampZeltdorf?.ToString("o");
+        set
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                TimeStampZeltdorf = null;
+            else if (DateTime.TryParse(value, null, System.Globalization.DateTimeStyles.RoundtripKind, out var result))
+                TimeStampZeltdorf = result;
+            else
+                TimeStampZeltdorf = null;
+        }
+    }
 
     public string FeuerwehrOhneSonderzeichen
     {

--- a/LagerInsights/Views/EvaluationView.xaml
+++ b/LagerInsights/Views/EvaluationView.xaml
@@ -393,6 +393,24 @@
                                 </DataTemplate>
                             </Button.ContentTemplate>
                         </Button>
+                        <Button Content="E-Mail Adressen kopieren"
+                                ToolTip="Kopiert alle E-Mail Adressen der Teilnehmenden in die Zwischenablage, sodass diese in Outlook eingefügt werden können."
+                                Click="KopiereEMailAdressen_Click"
+                                Margin="10,10,10,10">
+                            <Button.ContentTemplate>
+                                <DataTemplate>
+                                    <StackPanel Orientation="Horizontal">
+                                        <iconPacks:PackIconMaterial Width="22"
+                                                                    Height="22"
+                                                                    VerticalAlignment="Center"
+                                                                    Kind="Email" />
+                                        <TextBlock Margin="4 0 0 0"
+                                                   VerticalAlignment="Center"
+                                                   Text="{Binding}" />
+                                    </StackPanel>
+                                </DataTemplate>
+                            </Button.ContentTemplate>
+                        </Button>
                     </StackPanel>
 
                 </Grid>

--- a/LagerInsights/Views/EvaluationView.xaml.cs
+++ b/LagerInsights/Views/EvaluationView.xaml.cs
@@ -365,15 +365,15 @@ public partial class EvaluationView : Window
             await Task.WhenAll(tasks);
 
             if (tasks.All(task => task.Result))
-                ShowExportMessageBox("Export der Platzierungslisten abgeschlossen!\nZielverzeichnis öffnen?",
-                    "Export Platzierungslisten", exportPath);
+                ShowExportMessageBox("Export der Gruppenliste abgeschlossen!\nZielverzeichnis öffnen?",
+                    "Export Gruppenliste", exportPath);
             ((Button)sender).IsEnabled = true;
         }
         catch (Exception ex)
         {
             ((Button)sender).IsEnabled = true;
             LOGGING.Write(ex.Message, MethodBase.GetCurrentMethod().Name, EventLogEntryType.Error);
-            MessageBox.Show($"Export der Platzierungslisten fehlgeschlagen!\n{ex}", "Fehler: Export Platzierungslisten",
+            MessageBox.Show($"Export der Gruppenliste fehlgeschlagen!\n{ex}", "Fehler: Export Gruppenliste",
                 MessageBoxButton.OK, MessageBoxImage.Error);
         }
     }

--- a/LagerInsights/Views/EvaluationView.xaml.cs
+++ b/LagerInsights/Views/EvaluationView.xaml.cs
@@ -36,7 +36,7 @@ public partial class EvaluationView : Window
             try
             {
                 double prozentwert = mainViewModel.Gruppen.Where(x =>
-                    x.GezahlterBeitrag >= x.ZuBezahlenderBetrag && x.Einverstaendniserklaerung==true).ToList().Count();
+                    x.GezahlterBeitrag >= x.ZuBezahlenderBetrag && x.Einverstaendniserklaerung == true).ToList().Count();
                 var prozentsatz = prozentwert / grundwert * 100d;
                 Bezahlfortschritt.Value = prozentsatz;
                 AnzahlFehlenderGruppen.Content = grundwert - prozentwert;
@@ -631,6 +631,39 @@ public partial class EvaluationView : Window
 
             LOGGING.Write(ex.Message, MethodBase.GetCurrentMethod().Name, EventLogEntryType.Error);
             MessageBox.Show($"Export der Urkundenvorlage fehlgeschlagen!\n{ex}", "Fehler: Export Urkundenvorlage",
+                MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+
+
+    private void KopiereEMailAdressen_Click(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            ((Button)sender).IsEnabled = false;
+            var viewModel = (MainViewModel)DataContext;
+
+            // Alle E-Mail-Adressen der Teilnehmenden sammeln  
+            var emailAdressen = viewModel.Gruppen
+                .Select(g => g.Verantwortlicher.Email)
+                .Where(email => !string.IsNullOrWhiteSpace(email))
+                .Distinct();
+
+            // Semikolon-separierten String erstellen  
+            var emailString = string.Join(";", emailAdressen);
+
+            // In die Zwischenablage kopieren  
+            Clipboard.SetText(emailString);
+
+            MessageBox.Show("Die E-Mail-Adressen wurden in die Zwischenablage kopiert und können nun in Outlook eingefügt werden.",
+                "E-Mail-Adressen kopiert", MessageBoxButton.OK, MessageBoxImage.Information);
+            ((Button)sender).IsEnabled = true;
+        }
+        catch (Exception ex)
+        {
+            ((Button)sender).IsEnabled = true;
+            LOGGING.Write(ex.Message, MethodBase.GetCurrentMethod().Name, EventLogEntryType.Error);
+            MessageBox.Show($"Das Kopieren der E-Mail-Adressen ist fehlgeschlagen!\n{ex}", "Fehler: Kopieren der E-Mail-Adressen",
                 MessageBoxButton.OK, MessageBoxImage.Error);
         }
     }

--- a/LagerInsights/Views/MainWindow.xaml.cs
+++ b/LagerInsights/Views/MainWindow.xaml.cs
@@ -486,55 +486,62 @@ public partial class MainWindow : MetroWindow
 
             // Deserialisieren der XML-Datei und Hinzufügen der deserialisierten Gruppen zum ViewModel
             var jugendfeuerwehr = DeserializeXML<Jugendfeuerwehr>.Deserialize<Jugendfeuerwehr>(file);
-
-            if (jugendfeuerwehr != null)
+            if (jugendfeuerwehr == null)
             {
-                //Schauen ob bereits vorhanden und alten Eintrag löschen
-                if (ueberrschreiben)
-                {
-                    var gefundeneGruppen = viewModel.Gruppen.Where(x => x.Feuerwehr.Equals(jugendfeuerwehr.Feuerwehr))
-                        .ToList();
+                LOGGING.Write("Die Datei konnte nicht korrekt geparst werden. Überprüfen Sie die Struktur und den Inhalt der XML-Datei.", MethodBase.GetCurrentMethod().Name, EventLogEntryType.Error);
+                MessageBox.Show($"Die Datei konnte nicht korrekt geparst werden. Überprüfen Sie die Struktur und den Inhalt der XML-Datei.", "Fehler: SFTP Sync", MessageBoxButton.OK,
+                    MessageBoxImage.Error);
 
-                    foreach (var gefundeneGruppe in gefundeneGruppen)
-                    {
-                        // Der gezahlte Betrag soll nur überschrieben werden, wenn der Zeitstempel neuer ist
-                        if (gefundeneGruppe.TimeStampGezahlterBeitrag != null &&
-                            (jugendfeuerwehr.TimeStampGezahlterBeitrag == null || gefundeneGruppe.TimeStampGezahlterBeitrag > jugendfeuerwehr.TimeStampGezahlterBeitrag))
-                        {
-                            jugendfeuerwehr.GezahlterBeitrag = gefundeneGruppe.GezahlterBeitrag;
-                        }
-
-                        // Das Zeltdorf soll nur überschrieben werden, wenn der Zeitstempel neuer ist
-                        if (gefundeneGruppe.TimeStampZeltdorf != null &&
-                            (jugendfeuerwehr.TimeStampZeltdorf == null || gefundeneGruppe.TimeStampZeltdorf > jugendfeuerwehr.TimeStampZeltdorf))
-                        {
-                            jugendfeuerwehr.Zeltdorf = gefundeneGruppe.Zeltdorf;
-                        }
-
-                        // Die Einverständniserklärung soll nur überschrieben werden, wenn der Zeitstempel neuer ist
-                        if (gefundeneGruppe.TimeStampEinverstaendniserklaerung != null &&
-                            (jugendfeuerwehr.TimeStampEinverstaendniserklaerung == null || gefundeneGruppe.TimeStampEinverstaendniserklaerung > jugendfeuerwehr.TimeStampEinverstaendniserklaerung))
-                        {
-                            jugendfeuerwehr.Einverstaendniserklaerung = gefundeneGruppe.Einverstaendniserklaerung;
-                        }
-
-                        //Hinweis an Benutzer das die Gruppe existiert
-                        if (showOverrideInfo)
-                            MessageBox.Show(
-                                $"Die JF {jugendfeuerwehr.Feuerwehr} aus {jugendfeuerwehr.Organisationseinheit} Existierte bereits und wurde überschrieben!\nURL der Anmeldung neu: {jugendfeuerwehr.UrlderAnmeldung}\nURL der Anmeldung alt: {gefundeneGruppe.UrlderAnmeldung}",
-                                "Anmeldung wurde überschrieben!", MessageBoxButton.OK, MessageBoxImage.Warning);
-
-                        // Alte Gruppe löschen
-                        viewModel.RemoveSelectedGroup(gefundeneGruppe, false);
-                    }
-                }
-
-                //Neuen Eintrag importieren
-                viewModel.AddGroup(jugendfeuerwehr);
+                throw new InvalidDataException("Die Datei konnte nicht korrekt geparst werden. Überprüfen Sie die Struktur und den Inhalt der XML-Datei.");
             }
+
+            //Schauen ob bereits vorhanden und alten Eintrag löschen
+            if (ueberrschreiben)
+            {
+                var gefundeneGruppen = viewModel.Gruppen.Where(x => x.Feuerwehr.Equals(jugendfeuerwehr.Feuerwehr))
+                    .ToList();
+
+                foreach (var gefundeneGruppe in gefundeneGruppen)
+                {
+                    // Der gezahlte Betrag soll nur überschrieben werden, wenn der Zeitstempel neuer ist
+                    if (gefundeneGruppe.TimeStampGezahlterBeitrag != null &&
+                        (jugendfeuerwehr.TimeStampGezahlterBeitrag == null || gefundeneGruppe.TimeStampGezahlterBeitrag > jugendfeuerwehr.TimeStampGezahlterBeitrag))
+                    {
+                        jugendfeuerwehr.GezahlterBeitrag = gefundeneGruppe.GezahlterBeitrag;
+                    }
+
+                    // Das Zeltdorf soll nur überschrieben werden, wenn der Zeitstempel neuer ist
+                    if (gefundeneGruppe.TimeStampZeltdorf != null &&
+                        (jugendfeuerwehr.TimeStampZeltdorf == null || gefundeneGruppe.TimeStampZeltdorf > jugendfeuerwehr.TimeStampZeltdorf))
+                    {
+                        jugendfeuerwehr.Zeltdorf = gefundeneGruppe.Zeltdorf;
+                    }
+
+                    // Die Einverständniserklärung soll nur überschrieben werden, wenn der Zeitstempel neuer ist
+                    if (gefundeneGruppe.TimeStampEinverstaendniserklaerung != null &&
+                        (jugendfeuerwehr.TimeStampEinverstaendniserklaerung == null || gefundeneGruppe.TimeStampEinverstaendniserklaerung > jugendfeuerwehr.TimeStampEinverstaendniserklaerung))
+                    {
+                        jugendfeuerwehr.Einverstaendniserklaerung = gefundeneGruppe.Einverstaendniserklaerung;
+                    }
+
+                    //Hinweis an Benutzer das die Gruppe existiert
+                    if (showOverrideInfo)
+                        MessageBox.Show(
+                            $"Die JF {jugendfeuerwehr.Feuerwehr} aus {jugendfeuerwehr.Organisationseinheit} Existierte bereits und wurde überschrieben!\nURL der Anmeldung neu: {jugendfeuerwehr.UrlderAnmeldung}\nURL der Anmeldung alt: {gefundeneGruppe.UrlderAnmeldung}",
+                            "Anmeldung wurde überschrieben!", MessageBoxButton.OK, MessageBoxImage.Warning);
+
+                    // Alte Gruppe löschen
+                    viewModel.RemoveSelectedGroup(gefundeneGruppe, false);
+                }
+            }
+
+            //Neuen Eintrag importieren
+            viewModel.AddGroup(jugendfeuerwehr);
+
         }
         catch (Exception ex)
         {
+            if (ex is InvalidDataException) throw;
             LOGGING.Write(ex.Message, MethodBase.GetCurrentMethod().Name, EventLogEntryType.Error);
         }
     }
@@ -554,7 +561,7 @@ public partial class MainWindow : MetroWindow
 
             //Upload Pfad erstellen
             var uploadlocalPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                AppDomain.CurrentDomain.FriendlyName, "ftp", "upload");
+               AppDomain.CurrentDomain.FriendlyName, "ftp", "upload");
             _ = Directory.CreateDirectory(uploadlocalPath);
 
             // Liste zum Speichern der Dateipfade
@@ -591,7 +598,6 @@ public partial class MainWindow : MetroWindow
             // Heruntergeladene Daten importieren.
             //Hier wird auch sichergestellt das immer nur die neuesten Werte aus beiden Anmeldungen behalten werden.
             foreach (var file in filePaths) OpenDeserializerForFile(file, true, false);
-
             // Alle Dateien zum Server hochladen 
             List<string> dateienZumUpload = new List<string>();
             foreach (var gruppe in viewModel.Gruppen)
@@ -614,7 +620,7 @@ public partial class MainWindow : MetroWindow
                 foreach (var datei in dateienZumUpload)
                 {
                     sftp.UploadFile(File.OpenRead(Path.Combine(uploadlocalPath, datei)),
-                        $"{einstellungen.Pfad}/{datei}", true);
+                       $"{einstellungen.Pfad}/{datei}", true);
                 }
                 sftp.Disconnect();
 


### PR DESCRIPTION
Bugfix für Sync FTP der zum Überschreiben von Werten Online geführt hat, wenn die XML Datei nicht die erwartete Syntax hatte.

E-Mail Adressen alle Gruppen können nun in der Auswertung kopiert werden, zur einfachen Verwendung für BCC in Outlook.